### PR TITLE
New way of defining routes

### DIFF
--- a/modules/Main/Config/routes.php
+++ b/modules/Main/Config/routes.php
@@ -1,8 +1,6 @@
 <?php
 
-return array(
-    
-    array ('', 'GET', 'MainController', 'indexAction'),
-    array ('[:alpha]', 'GET', 'MainController', 'indexAction'),
-       
-);
+return function($route){
+    $route->add('', 'GET', 'MainController', 'indexAction');
+    $route->add('[:alpha]', 'GET', 'MainController', 'indexAction');
+};


### PR DESCRIPTION
Not compatible with previous versions, but easy to migrate:

Example:

// Old routes:
return array(
array ('', 'GET', 'MainController', 'indexAction'),
array ('[:alpha]', 'GET', 'MainController', 'indexAction'),
array ('something/[:num]', 'GET', 'SomeController', 'indexAction'),
);

// Awesome routes:
return function($route){
$route->add('', 'GET', 'MainController', 'indexAction');
$route->add('[:alpha]', 'GET', 'MainController', 'indexAction');
$route->add('something/[:num]', 'GET', 'SomeController', 'indexAction');
};